### PR TITLE
Fix tspawnat on julia 1.7+ by making the task sticky

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -15,10 +15,7 @@ jobs:
       matrix:
         julia-version: ['1.6', '1', 'nightly']
         julia-arch: [x64]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        exclude:
-          - os: macOS-latest
-            julia-arch: x86
+        os: [ubuntu-latest] # macos & windows don't support xvfb
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@master
+        env:
+          JULIA_NUM_THREADS: 2
         with:
           coverage: false
           prefix: xvfb-run

--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -1,0 +1,38 @@
+name: Run tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags: '*'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['1.6', '1', 'nightly']
+        julia-arch: [x64]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: macOS-latest
+            julia-arch: x86
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-runtest@master
+        with:
+          coverage: false
+      # - uses: julia-actions/julia-processcoverage@v1
+      # - uses: codecov/codecov-action@v1
+      #   with:
+      #     file: ./lcov.info
+      #     flags: unittests
+      #     name: codecov-umbrella
+      #     fail_ci_if_error: false
+      #     token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: julia-actions/julia-runtest@master
         with:
           coverage: false
+          prefix: xvfb-run
       # - uses: julia-actions/julia-processcoverage@v1
       # - uses: codecov/codecov-action@v1
       #   with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreadPools"
 uuid = "b189fb0b-2eb5-4ed4-bc0c-d34c51242431"
 authors = ["Trey Roessig <roessig.trey@gmail.com"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 
 let cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no runtests_exec.jl`
-    for test_nthreads in (1, 2, 4) # run once to try single-threaded mode, then try a couple times to trigger bad races
+    for test_nthreads in sort(collect(Set((1, 2, Threads.nthreads())))) # run once to try single-threaded mode, then try a couple times to trigger bad races
         new_env = copy(ENV)
         new_env["JULIA_NUM_THREADS"] = string(test_nthreads)
         println("\n# Threads = $test_nthreads")


### PR DESCRIPTION
Fixes #32 

I wasn't sure of the implication of setting `sticky = true` on < v1.7, so I played safe and left that as-is

cc. @Octogonapus @carstenbauer